### PR TITLE
Added simple_history version 1.1 to vars.yml

### DIFF
--- a/vars.yml
+++ b/vars.yml
@@ -28,6 +28,7 @@ pip_packages:
   - django-netfields==0.2.2
   - ipaddress==1.0.6
   - geopy==0.99
+  - simple_history==1.1
 services:
   - postgresql-9.2
   - httpd


### PR DESCRIPTION
While attempting to run the vagrant script I noticed that one module (simple_history) was missing. This caused the syncdb step in the vagrant provisioning to fail.
